### PR TITLE
Timebar graph

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@globalfishingwatch/api-client": "0.0.20-dataviews4",
     "@globalfishingwatch/layer-composer": "0.5.1",
-    "@globalfishingwatch/map-components": "3.1.0",
+    "@globalfishingwatch/map-components": "3.2.0",
     "@testing-library/jest-dom": "4.2.4",
     "@testing-library/react": "9.5.0",
     "@testing-library/user-event": "7.1.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
-    "@globalfishingwatch/api-client": "0.0.20",
+    "@globalfishingwatch/api-client": "0.0.20-dataviews4",
     "@globalfishingwatch/layer-composer": "0.5.1",
     "@globalfishingwatch/map-components": "3.1.0",
     "@testing-library/jest-dom": "4.2.4",

--- a/src/TimebarWrapper.container.ts
+++ b/src/TimebarWrapper.container.ts
@@ -27,7 +27,6 @@ const getGeoJSONTracksData = createSelector(
     return geoJSONTracks
   }
 )
-
 const getLoading = createSelector([getLoaders], (loaders: Loader[]): boolean => {
   return loaders.filter((l) => l.areas.includes('timebar')).length > 0
 })

--- a/src/TimebarWrapper.css
+++ b/src/TimebarWrapper.css
@@ -1,0 +1,44 @@
+.graphSelector {
+  position: absolute;
+  right: 10px;
+  bottom: 66px;
+  z-index: 100;
+}
+
+.graphSelector::after {
+  content: ' ';
+  position: absolute;
+  right: 10px;
+  top: 10px;
+  border-right: 2px solid white;
+  border-bottom: 2px solid white;
+  width: 5px;
+  height: 5px;
+  transform: rotateZ(45deg);
+}
+
+.graphSelectorSelect {
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  appearance: none;
+  border: 1px solid var(--color-foreground-transparent);
+  border-radius: 99px;
+  background: var(--color-background);
+  padding: 6px 16px 6px 24px;
+  color: white;
+
+  /* font-size: $font-size-xxs-small; */
+  text-transform: uppercase;
+}
+
+.graphSelectorSelect:focus {
+  outline-width: 0;
+  border-color: white;
+}
+
+.graphSelectorArrow {
+  display: inline-block;
+  position: absolute;
+  left: 7px;
+  top: 7px;
+}

--- a/src/TimebarWrapper.css
+++ b/src/TimebarWrapper.css
@@ -1,7 +1,7 @@
 .graphSelector {
   position: absolute;
-  right: 10px;
-  bottom: 66px;
+  right: 1rem;
+  bottom: 2.5rem;
   z-index: 100;
 }
 
@@ -24,7 +24,7 @@
   border: 1px solid var(--color-foreground-transparent);
   border-radius: 99px;
   background: var(--color-background);
-  padding: 6px 16px 6px 24px;
+  padding: 6px 24px 6px 16px;
   color: white;
 
   /* font-size: $font-size-xxs-small; */

--- a/src/TimebarWrapper.tsx
+++ b/src/TimebarWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react'
+import React, { Fragment, memo, useState, useMemo } from 'react'
 import Timebar, {
   TimebarTracks,
   TimebarActivity,
@@ -41,7 +41,9 @@ const TimebarWrapper = (props: any) => {
   const [currentGraph, setCurrentGraph] = useState(Graph.Speed)
 
   const segments = useMemo(() => tracksToSegments(tracks), [tracks])
-  const graph = useMemo(() => segmentsToGraph(segments, currentGraph), [segments, currentGraph])
+  const graph = useMemo(() => {
+    return segmentsToGraph(segments, currentGraph)
+  }, [segments, currentGraph])
 
   return (
     <div className="timebar">
@@ -56,27 +58,30 @@ const TimebarWrapper = (props: any) => {
           setTimerange(start, end)
         }}
       >
-        {(props: any) =>
-          loading ? (
+        {(props: any) => {
+          return loading ? (
             <Loader />
           ) : (
-            <>
+            <Fragment>
               {tracks.length && currentGraph === Graph.Encounters && (
                 <TimebarTracks key="tracks" {...props} tracks={tracks} />
               )}
               {tracks.length && currentGraph === Graph.Speed && (
                 <TimebarActivity
-                  {...props}
                   key="trackActivity"
+                  graphHeight={props.graphHeight}
+                  svgTransform={props.svgTransform}
+                  overallScale={props.overallScale}
+                  outerWidth={props.outerWidth}
                   // color={featureGraph.color}
                   // opacity={0.4}
                   // curve="curveBasis"
                   graphTracks={graph}
                 />
               )}
-            </>
+            </Fragment>
           )
-        }
+        }}
       </Timebar>
       <div className="graphSelector">
         <select
@@ -99,4 +104,4 @@ const TimebarWrapper = (props: any) => {
   )
 }
 
-export default TimebarWrapper
+export default memo(TimebarWrapper)

--- a/src/TimebarWrapper.tsx
+++ b/src/TimebarWrapper.tsx
@@ -1,9 +1,17 @@
-import React from 'react'
+import React, { useState } from 'react'
 import Timebar, { TimebarTracks } from '@globalfishingwatch/map-components/components/timebar'
 import Loader from './Loader'
+import './TimebarWrapper.css'
+
+enum Graph {
+  Encounters = 'Encounters',
+  Speed = 'Speed',
+}
 
 const TimebarWrapper = (props: any) => {
   const { start, end, tracks, setTimerange, loading } = props
+
+  const [currentGraph, setCurrentGraph] = useState(Graph.Speed)
 
   return (
     <div className="timebar">
@@ -22,10 +30,32 @@ const TimebarWrapper = (props: any) => {
           loading ? (
             <Loader />
           ) : (
-            <>{tracks.length && <TimebarTracks key="tracks" {...props} tracks={tracks} />}</>
+            <>
+              {tracks.length && currentGraph === Graph.Encounters && (
+                <TimebarTracks key="tracks" {...props} tracks={tracks} />
+              )}
+              {tracks.length && currentGraph === Graph.Speed && <div></div>}
+            </>
           )
         }
       </Timebar>
+      <div className="graphSelector">
+        <select
+          className="graphSelectorSelect"
+          onChange={(event) => {
+            setCurrentGraph(event.target.value as Graph)
+          }}
+          value={currentGraph}
+        >
+          <option key={Graph.Encounters} value={Graph.Encounters}>
+            {Graph.Encounters}
+          </option>
+          <option key={Graph.Speed} value={Graph.Speed}>
+            {Graph.Speed}
+          </option>
+        </select>
+        <div className="graphSelectorArrow">{/* <Icon icon="graph" /> */}</div>
+      </div>
     </div>
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,11 @@
 :root {
+  /* SIZES */
+
+  /* TYPE */
+  --font-family: 'Roboto', sans-serif;
+  --font-weight-regular: 400;
+  --font-size-L: 1.6rem;
+
   /* COLORS */
   --color-brand: rgba(22, 63, 137, 1);
   --color-background-rgb: 10, 23, 56;
@@ -8,24 +15,19 @@
   --color-foreground-transparent: rgba(255, 255, 255, 0.5);
 }
 
-body {
-  margin: 0;
-  font-family:
-    -apple-system,
-    BlinkMacSystemFont,
-    'Segoe UI',
-    'Roboto',
-    'Oxygen',
-    'Ubuntu',
-    'Cantarell',
-    'Fira Sans',
-    'Droid Sans',
-    'Helvetica Neue',
-    sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+html {
+  font-size: 10px;
 }
 
-code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
+body {
+  margin: 0;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-family: var(--font-family);
+  font-weight: var(--font-weight-regular);
+  font-size: var(--font-size-L);
+  color: var(--color-brand);
+  height: 100vh;
+  width: 100vw;
+  overflow-x: hidden;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -5,6 +5,7 @@
   --color-background: rgb(var(--color-background-rgb));
   --color-background-transparent: rgba(var(--color-background-rgb), 0.5);
   --color-foreground: white;
+  --color-foreground-transparent: rgba(255, 255, 255, 0.5);
 }
 
 body {

--- a/src/model/route.selectors.ts
+++ b/src/model/route.selectors.ts
@@ -9,15 +9,12 @@ const getLocationQuery = createSelector([getLocation], (location) => {
 })
 
 const getQueryParam = (param: QueryParam) =>
-  createSelector(
-    [getLocationQuery],
-    (query: any) => {
-      if (query === undefined || query[param] === undefined) {
-        return DEFAULT_WORKSPACE[param]
-      }
-      return query[param]
+  createSelector([getLocationQuery], (query: any) => {
+    if (query === undefined || query[param] === undefined) {
+      return DEFAULT_WORKSPACE[param]
     }
-  )
+    return query[param]
+  })
 
 export const getDataviewsQuery = getQueryParam('dataviewsWorkspace')
 

--- a/src/model/routes.ts
+++ b/src/model/routes.ts
@@ -4,14 +4,9 @@ import { dataviewsThunk } from './thunks'
 
 export const HOME = 'HOME'
 
-const preFetchThunks = [
-  dataviewsThunk,
-]
+const preFetchThunks = [dataviewsThunk]
 
-const thunk = async (
-  dispatch: Dispatch<any>,
-  getState: StateGetter<any>
-) => {
+const thunk = async (dispatch: Dispatch<any>, getState: StateGetter<any>) => {
   preFetchThunks.forEach((thunk) => thunk(dispatch, getState))
 }
 

--- a/src/model/store.ts
+++ b/src/model/store.ts
@@ -56,19 +56,19 @@ const routerQueryMiddleware: Middleware = ({ getState }) => (next) => (action: a
   const isRouterAction = routesActions.includes(action.type)
   if (!isRouterAction) {
     next(action)
-  }
+  } else {
+    const newAction: any = { ...action }
 
-  const newAction: any = { ...action }
-
-  const prevQuery = getState().location.query || {}
-  if (newAction.replaceQuery !== true) {
-    newAction.query = {
-      ...prevQuery,
-      ...newAction.query,
+    const prevQuery = getState().location.query || {}
+    if (newAction.replaceQuery !== true) {
+      newAction.query = {
+        ...prevQuery,
+        ...newAction.query,
+      }
     }
-  }
 
-  next(newAction)
+    next(newAction)
+  }
 }
 
 const { reducer, middleware, enhancer } = connectRoutes(routesMap, routesOptions)

--- a/src/model/thunks.ts
+++ b/src/model/thunks.ts
@@ -37,12 +37,12 @@ const dataviewsClient = new DataviewsClient(
 export const dataviewsThunk = async (dispatch: Dispatch, getState: StateGetter<any>) => {
   const state = getState()
   const dataviewsQuery = getDataviewsQuery(state)
-  // TODO: improve this loading diffing
+
   if (dataviewsQuery) {
-    // console.log('dataviews query:', dataviewsQuery)
-    dispatch(startLoading({ id: 'dataviews', areas: ['map', 'timebar'] }))
+    // TODO: better handle of loading when no new dataviews to load, removing for now to avoid unnecesary rerenders
+    // dispatch(startLoading({ id: 'dataviews', areas: ['map', 'timebar'] }))
     const dataviews = await dataviewsClient.load(dataviewsQuery)
-    dispatch(completeLoading({ id: 'dataviews' }))
+    // dispatch(completeLoading({ id: 'dataviews' }))
     // console.log(dataviews)
     if (dataviews === null) {
       console.log('no updates, dont trigger any action')

--- a/yarn.lock
+++ b/yarn.lock
@@ -1008,10 +1008,10 @@
     pbf "^3.2.1"
     vt-pbf "^3.1.1"
 
-"@globalfishingwatch/map-components@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@globalfishingwatch/map-components/-/map-components-3.1.0.tgz#e9247a44a07bc803233adcfbb88bd9b85094bf23"
-  integrity sha512-XsGgeOzgJsLVlzZZRK/THQbBbpQmkHqqNa5zZVCs+159SB+Dur7RCIDVKRrarvER2NY3BP+wCleW1orGR5nsQw==
+"@globalfishingwatch/map-components@3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@globalfishingwatch/map-components/-/map-components-3.2.0.tgz#6c3f590fd33712d3a8da7866d5e1c5756a0e53db"
+  integrity sha512-IRJj69vtQr5YQqPYWWrVP0DwaHqrEB+stoKmFJUk0EJHUj/FURAn6V/wH3kaSBHPkLwhmayI7az9iXlpyO/sLw==
   dependencies:
     "@globalfishingwatch/map-convert" "github:GlobalFishingWatch/map-convert"
     "@mapbox/tile-cover" "^3.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -983,12 +983,13 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18"
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
-"@globalfishingwatch/api-client@0.0.20":
-  version "0.0.20"
-  resolved "https://registry.yarnpkg.com/@globalfishingwatch/api-client/-/api-client-0.0.20.tgz#858339a8924c6e796c152f815e47c4b9cd1447a6"
-  integrity sha512-FtJ7FGuqHJyk8xrgUVgSPj5LdN2WzBIKPezRMu8L2ieoETH9rTBRLRGD9IfmL22ahGyPmHlbrqtvkzt7OZUmPQ==
+"@globalfishingwatch/api-client@0.0.20-dataviews4":
+  version "0.0.20-dataviews4"
+  resolved "https://registry.yarnpkg.com/@globalfishingwatch/api-client/-/api-client-0.0.20-dataviews4.tgz#86a19b7adada0427aa7979a08ea32cd89c5e1ed8"
+  integrity sha512-yUZUL2wxo/e5DZmyC3CwtS1XL352sVOTxqVX7qIbQVUZBMbfdO8qSpMa5+NSWdjTckajqj0CgiT6eV30R+WfZw==
   dependencies:
     file-saver "^2.0.2"
+    lodash "^4.17.15"
 
 "@globalfishingwatch/layer-composer@0.5.1":
   version "0.5.1"


### PR DESCRIPTION
Adds a selector to the timebar to show the speed graph instead of the track lines.

Works with https://github.com/GlobalFishingWatch/track-inspector/pull/34

It works but has issues:
- data from the API has extreme outliers, ie one point with speed >1000 which makes the whole graph barely visible. We could wait for a data/backend fix or patch up a front-end solution, ie remove values that are 500% higher than the second value. For now we just cap at an arbitrary number: https://github.com/GlobalFishingWatch/map-components/pull/110/files#diff-89b14543e53fe5c986cda89266c1d59eR47
- performance is very poor because track has several hundred thousand points, and memoize doesn't work properly. The Timebar graph gets a new reference for the data (`graphTracks` : https://github.com/GlobalFishingWatch/map-components/pull/110/files#diff-89b14543e53fe5c986cda89266c1d59eR95) at every frame (ie start/end changes), so it's running the algo to generate the graph again and again. I don't understand that as it is correctly memoized from outside (from track inspector), see https://github.com/GlobalFishingWatch/track-inspector/pull/34/files#diff-81faf7cd26696fc3108ab71700e77ecdR44
- if fixing this is not enough, should we use a similar strategy than for tracks in the map, ie reduce the number of points of the track depending on the "temporal zoom"?