### PR TITLE
fix time format in the mapinfo box

### DIFF
--- a/src/features/map/MapInfo.tsx
+++ b/src/features/map/MapInfo.tsx
@@ -20,8 +20,8 @@ const MapInfo = ({ center }: { center: LatLon | null }) => {
     let endFormatted = endDT.toLocaleString(DateTime.DATE_MED)
     const timeΔ = new Date(end).getTime() - new Date(start).getTime()
     if (timeΔ < A_DAY) {
-      stFormatted = [stFormatted, startDT.toLocaleString(DateTime.TIME_24_SIMPLE), 'UTC'].join(' ')
-      endFormatted = [endFormatted, endDT.toLocaleString(DateTime.TIME_24_SIMPLE), 'UTC'].join(' ')
+      stFormatted = [startDT.toLocaleString(DateTime.DATETIME_MED), 'UTC'].join(' ')
+      endFormatted = [endDT.toLocaleString(DateTime.DATETIME_MED), 'UTC'].join(' ')
     }
     return `${stFormatted} - ${endFormatted}`
   }, [start, end])


### PR DESCRIPTION
Replace the 24 hours time format to 12 hours time format when we filter by day

![image](https://user-images.githubusercontent.com/1672451/87163749-38b18200-c29e-11ea-9a28-f81a3a8b9819.png)

https://github.com/GlobalFishingWatch/gfw-eng-tasks/issues/117