### PR TITLE
Speed graph patch

### DIFF
--- a/src/data-transform/trackValueArrayToSegments.ts
+++ b/src/data-transform/trackValueArrayToSegments.ts
@@ -78,7 +78,17 @@ export default (valueArray: number[], fields_: Field[]) => {
       if (value === nullValue) {
         currentPoint[field] = null
       } else {
-        currentPoint[field] = field === Field.timestamp ? value * 1000 : value / 1000000
+        switch (field) {
+          case Field.timestamp:
+            currentPoint[field] = value * 1000
+            break
+          case Field.speed:
+            currentPoint[field] = value
+            break
+          default:
+            currentPoint[field] = value / 1000000
+            break
+        }
       }
 
       pointsFieldIndex++


### PR DESCRIPTION
Do not divide speed values by 100 000 because of an API change 